### PR TITLE
Guard backend logs and coerce expense amounts

### DIFF
--- a/backend/getExpenses.js
+++ b/backend/getExpenses.js
@@ -10,7 +10,7 @@ export const handler = async () => {
 
     const expenses = data.Items.map((item) => ({
         id: item.id.S,
-        amount: item.amount.N,
+        amount: Number(item.amount.N),
         category: item.category.S,
         date: item.date.S,
     }));
@@ -19,5 +19,7 @@ export const handler = async () => {
     return { statusCode: 200, body: JSON.stringify(expenses) };
 };
 
-console.log("API_BASE:", API_BASE);
-console.log("Full URL:", `${API_BASE}/getExpenses`);
+if (typeof API_BASE !== "undefined") {
+    console.log("API_BASE:", API_BASE);
+    console.log("Full URL:", `${API_BASE}/getExpenses`);
+}


### PR DESCRIPTION
## Summary
- guard the backend logging of API_BASE so the handler can run without the global
- coerce DynamoDB numeric attributes to numbers before returning expenses

## Testing
- not run (requires AWS credentials to scan the Expenses table)


------
https://chatgpt.com/codex/tasks/task_e_68d94bd32fa48321862294b7216ac20b