### PR TITLE
Capture new expense metadata

### DIFF
--- a/backend/addExpense.js
+++ b/backend/addExpense.js
@@ -6,22 +6,41 @@ const client = new DynamoDBClient();
 
 
 export const handler = async (event) => {
-    const body = JSON.parse(event.body);
+    const body = JSON.parse(event.body ?? "{}");
 
+    const amountValue = Number(body.amount);
+    const categoryValue = typeof body.category === "string" ? body.category.trim() : "";
+    const dateValue = typeof body.date === "string" ? body.date.trim() : "";
+
+    if (!Number.isFinite(amountValue) || categoryValue === "" || dateValue === "") {
+        return { statusCode: 400, body: JSON.stringify({ message: "Invalid expense payload" }) };
+    }
+
+    const item = {
+        id: { S: uuidv4() },
+        amount: { N: amountValue.toString() },
+        category: { S: categoryValue },
+        date: { S: dateValue },
+    };
+
+    if (typeof body.name === "string" && body.name.trim() !== "") {
+        item.name = { S: body.name.trim() };
+    }
+
+    if (typeof body.method === "string" && body.method.trim() !== "") {
+        item.method = { S: body.method.trim() };
+    }
+
+    if (typeof body.status === "string" && body.status.trim() !== "") {
+        item.status = { S: body.status.trim() };
+    }
 
     const params = {
         TableName: "Expenses",
-        Item: {
-            id: { S: uuidv4() },
-            amount: { N: body.amount.toString() },
-            category: { S: body.category },
-            date: { S: body.date },
-        },
+        Item: item,
     };
 
-
     await client.send(new PutItemCommand(params));
-
 
     return { statusCode: 200, body: JSON.stringify({ message: "Expense added!" }) };
 };

--- a/backend/getExpenses.js
+++ b/backend/getExpenses.js
@@ -7,12 +7,16 @@ const client = new DynamoDBClient();
 export const handler = async () => {
     const data = await client.send(new ScanCommand({ TableName: "Expenses" }));
 
+    const items = Array.isArray(data.Items) ? data.Items : [];
 
-    const expenses = data.Items.map((item) => ({
-        id: item.id.S,
-        amount: Number(item.amount.N),
-        category: item.category.S,
-        date: item.date.S,
+    const expenses = items.map((item) => ({
+        id: item?.id?.S,
+        amount: item?.amount?.N ? Number(item.amount.N) : undefined,
+        category: item?.category?.S,
+        date: item?.date?.S,
+        name: item?.name?.S,
+        method: item?.method?.S,
+        status: item?.status?.S,
     }));
 
 

--- a/frontend/src/components/ExpenseForm.js
+++ b/frontend/src/components/ExpenseForm.js
@@ -1,20 +1,41 @@
 import React, { useState } from "react";
 
 function ExpenseForm({ onAdd }) {
+  const [name, setName] = useState("");
   const [amount, setAmount] = useState("");
   const [category, setCategory] = useState("");
   const [date, setDate] = useState("");
+  const [method, setMethod] = useState("");
+  const [status, setStatus] = useState("");
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    onAdd({ amount, category, date });
+    onAdd({
+      name: name.trim(),
+      amount: Number(amount),
+      category,
+      date,
+      method: method.trim(),
+      status,
+    });
+    setName("");
     setAmount("");
     setCategory("");
     setDate("");
+    setMethod("");
+    setStatus("");
   };
 
   return (
     <form onSubmit={handleSubmit} className="mb-4 space-y-2">
+      <input
+        type="text"
+        placeholder="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        className="border p-2 w-full"
+        required
+      />
       <input
         type="number"
         placeholder="Amount"
@@ -38,6 +59,27 @@ function ExpenseForm({ onAdd }) {
         className="border p-2 w-full"
         required
       />
+      <input
+        type="text"
+        placeholder="Payment method"
+        value={method}
+        onChange={(e) => setMethod(e.target.value)}
+        className="border p-2 w-full"
+        required
+      />
+      <select
+        value={status}
+        onChange={(e) => setStatus(e.target.value)}
+        className="border p-2 w-full"
+        required
+      >
+        <option value="" disabled>
+          Select status
+        </option>
+        <option value="Pending">Pending</option>
+        <option value="Cleared">Cleared</option>
+        <option value="Scheduled">Scheduled</option>
+      </select>
       <button
         type="submit"
         className="bg-blue-500 text-white px-4 py-2 rounded"


### PR DESCRIPTION
## Summary
- persist the expense name, payment method, and status when storing new items in DynamoDB
- expose the additional attributes when reading expenses while tolerating records created before the change
- update the client form flow to send the new metadata and validate the inputs before posting

## Testing
- npm start -- --host 0.0.0.0 --port 3000


------
https://chatgpt.com/codex/tasks/task_e_68d95296b40c8321be7c04970c48c665